### PR TITLE
Add snacks.nvim picker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ Here is an example to create a mapping:
 vim.keymap.set("n", "<leader>ml", require("recall.snacks").pick, { noremap = true, silent = true })
 ```
 
+To change or unset the default mappings, use an empty string:
+
+```lua
+require("recall").setup({
+  snacks = {
+    mappings = {
+      unmark_selected_entry = {
+        normal = "d",
+        insert = "",
+      },
+    },
+  },
+})
+```
+
 ### Project-specific global marks
 
 Neovim stores global mark information in the [`shada` file][shada-docs]. The

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ _Telescope integration using `:Telescope recall theme=ivy`._
 
 - [Installation](#installation)
   - [Telescope integration](#telescope-integration)
+  - [Snacks Picker integration](#snacks-picker-integration)
   - [Project-specific global marks](#project-specific-global-marks)
   - [The `wshada` option](#the-wshada-option)
   - [Usage commands](#usage-commands)
@@ -154,6 +155,16 @@ require("recall").setup({
 })
 
 require("telescope").load_extension("recall")
+```
+
+### Snacks Picker integration
+
+You need to have Snacks Picker installed.
+The picker is available via `require("recall.snacks").pick`.
+Here is an example to create a mapping:
+
+```lua
+vim.keymap.set("n", "<leader>ml", require("recall.snacks").pick, { noremap = true, silent = true })
 ```
 
 ### Project-specific global marks

--- a/lua/recall/config.lua
+++ b/lua/recall/config.lua
@@ -14,6 +14,15 @@ M.opts = {
     },
   },
 
+  snacks = {
+    mappings = {
+      unmark_selected_entry = {
+        normal = "dd",
+        insert = "<M-d>",
+      },
+    },
+  },
+
   -- https://github.com/neovim/neovim/issues/4295
   -- https://github.com/neovim/neovim/pull/24936 (0.10-only)
   wshada = vim.fn.has("nvim-0.10") == 0,

--- a/lua/recall/snacks.lua
+++ b/lua/recall/snacks.lua
@@ -1,0 +1,28 @@
+local utils = require("recall.utils")
+
+local M = {}
+
+local function finder()
+  local marks = utils.sorted_global_marks()
+
+  local items = {}
+  for _, mark in ipairs(marks) do
+    table.insert(items, {
+      text = mark.char,
+      pos = { [1] = mark.info.pos[2], [2] = mark.info.pos[3] },
+      file = mark.info.file,
+    })
+  end
+
+  return items
+end
+
+M.pick = function()
+  require("snacks").picker.pick({
+    title = "Global Marks",
+    format = "text",
+    finder = finder,
+  })
+end
+
+return M

--- a/lua/recall/snacks.lua
+++ b/lua/recall/snacks.lua
@@ -4,6 +4,19 @@ local marking = require("recall.marking")
 
 local M = {}
 
+local function format(item, picker)
+  local a = require("snacks").picker.util.align
+
+  local ret = {}
+
+  ret[#ret + 1] = { a(config.opts.sign, 2), config.opts.sign_highlight }
+  ret[#ret + 1] = { " ", virtual = true }
+
+  vim.list_extend(ret, require("snacks").picker.format.file(item, picker))
+
+  return ret
+end
+
 local function finder()
   local marks = utils.sorted_global_marks()
 
@@ -11,7 +24,7 @@ local function finder()
   for _, mark in ipairs(marks) do
     table.insert(items, {
       char = mark.char,
-      text = mark.char,
+      text = mark.char .. " " .. mark.info.file,
       pos = { [1] = mark.info.pos[2], [2] = mark.info.pos[3] },
       file = mark.info.file,
     })
@@ -27,13 +40,14 @@ local function unmark_selected_entry(self, item)
     refresh = true,
   })
 end
+
 M.pick = function()
   local unmark_normal = config.opts.snacks.mappings.unmark_selected_entry.normal
   local unmark_insert = config.opts.snacks.mappings.unmark_selected_entry.insert
 
   require("snacks").picker.pick({
     title = "Global Marks",
-    format = "text",
+    format = format,
     finder = finder,
     actions = {
       unmark_selected_entry = unmark_selected_entry,

--- a/lua/recall/snacks.lua
+++ b/lua/recall/snacks.lua
@@ -1,4 +1,6 @@
+local config = require("recall.config")
 local utils = require("recall.utils")
+local marking = require("recall.marking")
 
 local M = {}
 
@@ -8,6 +10,7 @@ local function finder()
   local items = {}
   for _, mark in ipairs(marks) do
     table.insert(items, {
+      char = mark.char,
       text = mark.char,
       pos = { [1] = mark.info.pos[2], [2] = mark.info.pos[3] },
       file = mark.info.file,
@@ -17,11 +20,32 @@ local function finder()
   return items
 end
 
+local function unmark_selected_entry(self, item)
+  vim.cmd("delmarks " .. item.char)
+  marking.on_mark_update()
+  self:find({
+    refresh = true,
+  })
+end
 M.pick = function()
+  local unmark_normal = config.opts.snacks.mappings.unmark_selected_entry.normal
+  local unmark_insert = config.opts.snacks.mappings.unmark_selected_entry.insert
+
   require("snacks").picker.pick({
     title = "Global Marks",
     format = "text",
     finder = finder,
+    actions = {
+      unmark_selected_entry = unmark_selected_entry,
+    },
+    win = {
+      input = {
+        keys = {
+          [unmark_normal] = { "unmark_selected_entry", mode = { "n" }, desc = "Delete mark" },
+          [unmark_insert] = { "unmark_selected_entry", mode = { "i" }, desc = "Delete mark" },
+        },
+      },
+    },
   })
 end
 


### PR DESCRIPTION
This PR adds [snacks.nvim picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) (an alternative to Telescope) to the plugin. It allows users to use snacks.nvim picker to goto the selected mark. It also allows users to delete the selected mark like in the Telescope integration.

The following is what it looks like in snacks.nvim in this setup:

```lua
{
    "shihanng/recall.nvim", -- replace this line and the one below if this PR is accepted
    branch = "snacks-picker",
    config = function()
        local recall = require("recall")

        recall.setup({
            sign = "",
            sign_highlight = "@label",

            snacks = {
                mappings = {
                    unmark_selected_entry = {
                        insert = "<C-d>",
                    },
                },
            },
        })

        vim.keymap.set("n", "<leader>mm", recall.toggle, { noremap = true, silent = true })
        vim.keymap.set("n", "<C-m>", require("recall.snacks").pick, { noremap = true, silent = true })
    end,
}
```

<img width="1170" alt="SCR-20250504-lztz" src="https://github.com/user-attachments/assets/f6f833dd-de02-49b4-8188-628ec370b52c" />
