### PR TITLE
Fix fuzzy search over marks with telescope

### DIFF
--- a/lua/recall/telescope.lua
+++ b/lua/recall/telescope.lua
@@ -20,7 +20,7 @@ M.extension = function(opts)
     local _, lnum, _ = unpack(entry.value.info.pos)
     return entry_layout({
       { config.opts.sign, config.opts.sign_highlight },
-      entry.value.char .. ":" .. entry.value.info.file .. ":" .. lnum
+      entry.value.char .. ":" .. entry.value.info.file .. ":" .. lnum,
     })
   end
 

--- a/lua/recall/telescope.lua
+++ b/lua/recall/telescope.lua
@@ -19,7 +19,7 @@ M.extension = function(opts)
   local function display_entry(entry)
     return entry_layout({
       { config.opts.sign, config.opts.sign_highlight },
-      entry.value.info.file,
+      entry.value.char .. ":" .. entry.value.info.file .. ":" .. entry.value.info.pos[2]
     })
   end
 
@@ -31,7 +31,7 @@ M.extension = function(opts)
         return {
           value = entry,
           display = display_entry,
-          ordinal = entry.char,
+          ordinal = entry.char .. ":" .. entry.info.file .. ":" .. entry.info.pos[2],
           lnum = entry.info.pos[2],
           col = entry.info.pos[3] - 1,
           filename = entry.info.file,

--- a/lua/recall/telescope.lua
+++ b/lua/recall/telescope.lua
@@ -20,7 +20,7 @@ M.extension = function(opts)
     local _, lnum, _ = unpack(entry.value.info.pos)
     return entry_layout({
       { config.opts.sign, config.opts.sign_highlight },
-      entry.value.char .. ":" .. entry.value.info.file .. ":" .. lnum,
+      entry.value.char .. ":" .. vim.fn.fnamemodify(entry.value.info.file, ":.")  .. ":" .. lnum,
     })
   end
 
@@ -33,7 +33,7 @@ M.extension = function(opts)
         return {
           value = entry,
           display = display_entry,
-          ordinal = entry.char .. ":" .. entry.info.file .. ":" .. lnum,
+          ordinal = entry.char .. ":" .. vim.fn.fnamemodify(entry.info.file, ":.") .. ":" .. lnum,
           lnum = lnum,
           col = col - 1,
           filename = entry.info.file,

--- a/lua/recall/telescope.lua
+++ b/lua/recall/telescope.lua
@@ -17,9 +17,10 @@ M.extension = function(opts)
   })
 
   local function display_entry(entry)
+    local _, lnum, _ = unpack(entry.value.info.pos)
     return entry_layout({
       { config.opts.sign, config.opts.sign_highlight },
-      entry.value.char .. ":" .. entry.value.info.file .. ":" .. entry.value.info.pos[2]
+      entry.value.char .. ":" .. entry.value.info.file .. ":" .. lnum
     })
   end
 
@@ -28,12 +29,13 @@ M.extension = function(opts)
     return telescope_finders.new_table({
       results = marks,
       entry_maker = function(entry)
+        local _, lnum, col = unpack(entry.info.pos)
         return {
           value = entry,
           display = display_entry,
-          ordinal = entry.char .. ":" .. entry.info.file .. ":" .. entry.info.pos[2],
-          lnum = entry.info.pos[2],
-          col = entry.info.pos[3] - 1,
+          ordinal = entry.char .. ":" .. entry.info.file .. ":" .. lnum,
+          lnum = lnum,
+          col = col - 1,
           filename = entry.info.file,
         }
       end,

--- a/lua/recall/telescope.lua
+++ b/lua/recall/telescope.lua
@@ -20,7 +20,7 @@ M.extension = function(opts)
     local _, lnum, _ = unpack(entry.value.info.pos)
     return entry_layout({
       { config.opts.sign, config.opts.sign_highlight },
-      entry.value.char .. ":" .. vim.fn.fnamemodify(entry.value.info.file, ":.")  .. ":" .. lnum,
+      entry.value.char .. ":" .. vim.fn.fnamemodify(entry.value.info.file, ":.") .. ":" .. lnum,
     })
   end
 

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -180,5 +180,26 @@ describe("Recall", function()
     assert.are.equal(results[3].ordinal, "C:" .. temp_paths[1] .. ":20")
     assert.are.equal(results[3].lnum, 20)
     assert.are.equal(results[3].col, 0)
+
+    -- Switch to the temp dir to test relative filenames
+    vim.api.nvim_set_current_dir(vim.fs.dirname(temp_paths[1]))
+
+    vim.cmd("Telescope recall")
+
+    local results = inspect_telescope_results()
+
+    assert.are.equal(#results, 3)
+
+    assert.are.equal(results[1].ordinal, "A:" .. vim.fn.fnamemodify(temp_paths[1], ":p:.") .. ":1")
+    assert.are.equal(results[1].lnum, 1)
+    assert.are.equal(results[1].col, 0)
+
+    assert.are.equal(results[2].ordinal, "B:" .. vim.fn.fnamemodify(temp_paths[1], ":p:.") .. ":10")
+    assert.are.equal(results[2].lnum, 10)
+    assert.are.equal(results[2].col, 0)
+
+    assert.are.equal(results[3].ordinal, "C:" .. vim.fn.fnamemodify(temp_paths[1], ":p:.") .. ":20")
+    assert.are.equal(results[3].lnum, 20)
+    assert.are.equal(results[3].col, 0)
   end)
 end)

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -58,6 +58,10 @@ describe("Recall", function()
     set_lines(bufnr, line_count)
 
     local temp_path = luv.os_tmpdir() .. "/nvim-recall-test-" .. luv.hrtime() .. ".txt"
+    if jit and jit.os == "OSX" then
+      -- Need to add this path prefix on macos
+      temp_path = "/private" .. temp_path
+    end
     table.insert(temp_paths, temp_path)
 
     vim.api.nvim_buf_set_name(bufnr, temp_path)
@@ -165,15 +169,15 @@ describe("Recall", function()
 
     assert.are.equal(#results, 3)
 
-    assert.are.equal(results[1].ordinal, "A")
+    assert.are.equal(results[1].ordinal, "A:" .. temp_paths[1] .. ":1")
     assert.are.equal(results[1].lnum, 1)
     assert.are.equal(results[1].col, 0)
 
-    assert.are.equal(results[2].ordinal, "B")
+    assert.are.equal(results[2].ordinal, "B:" .. temp_paths[1] .. ":10")
     assert.are.equal(results[2].lnum, 10)
     assert.are.equal(results[2].col, 0)
 
-    assert.are.equal(results[3].ordinal, "C")
+    assert.are.equal(results[3].ordinal, "C:" .. temp_paths[1] .. ":20")
     assert.are.equal(results[3].lnum, 20)
     assert.are.equal(results[3].col, 0)
   end)

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -188,7 +188,7 @@ describe("Recall", function()
 
     vim.cmd("Telescope recall")
 
-    local results = inspect_telescope_results()
+    results = inspect_telescope_results()
 
     assert.are.equal(#results, 3)
 

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -47,6 +47,7 @@ describe("Recall", function()
   local bufnr
   local line_count = 100
   local temp_paths = {}
+  local cwd = vim.fn.getcwd()
 
   before_each(function()
     local telescope = require("telescope")
@@ -78,6 +79,7 @@ describe("Recall", function()
     end
 
     temp_paths = {}
+    vim.api.nvim_set_current_dir(cwd)
   end)
 
   it("can toggle marks and show/hide signs", function()


### PR DESCRIPTION
Fixes #11 

The `ordinal` value should be the same as the `display` value to support fuzzy search.

I also added some extra info (mark character and line number) to each entry to make them more unique incase you have multiple marks set in a single file e.g. `A:/Users/me/Workspace/notes.md:1`.