### PR TITLE
Reuse opened windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Recall will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0](https://github.com/fnune/recall.nvim/releases/tag/1.3.0) - 2026-03-04
+
+### Added
+
+- New `reuse_opened_windows` option (default: `false`). When enabled, navigation
+  reuses existing windows displaying the target buffer instead of switching buffers
+  in the current window. Useful for split-window workflows.
+
 ## [1.2.0](https://github.com/fnune/recall.nvim/releases/tag/1.2.0) - 2025-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ All notable changes to Recall will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0](https://github.com/fnune/recall.nvim/releases/tag/1.3.0) - 2026-03-04
+## [1.2.1](https://github.com/fnune/recall.nvim/releases/tag/1.2.1) - 2026-03-09
 
-### Added
+### Fixed
 
-- New `reuse_opened_windows` option (default: `false`). When enabled, navigation
-  reuses existing windows displaying the target buffer instead of switching buffers
-  in the current window. Useful for split-window workflows.
+- Navigation now reuses existing windows displaying the target buffer instead of switching buffers
+  in the current window.
 
 ## [1.2.0](https://github.com/fnune/recall.nvim/releases/tag/1.2.0) - 2025-05-28
 

--- a/README.md
+++ b/README.md
@@ -271,4 +271,3 @@ To format the code in this repository, run [`./format.sh`](./format.sh).
 ## Licensing
 
 [The MIT license](./LICENSE.md).
-

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ streamlining their usage and enhancing their visibility and navigability.
   circumventing the need for direct letter references.
 - Simplifies mark setting and removal with `:RecallToggle`, abstracting away
   the burden of choosing and remembering specific letters.
+- When navigating marks in a split-window layout, `recall` reuses existing windows
+instead of switching buffers in the current window.
 
 Recall attempts to eliminate the cognitive overhead associated with mark
 management, enabling you to focus on your workflow, not on mark administration.
@@ -181,21 +183,6 @@ require("recall").setup({
   },
 })
 ```
-
-### Reusing opened windows
-
-When navigating marks in a split-window layout, `recall` can reuse existing windows
-instead of switching buffers in the current window.
-
-```lua
-require("recall").setup({
-  reuse_opened_windows = true  -- default: false
-})
-```
-
-When enabled, `recall` first checks if the target mark's buffer is already open in
-another window. If so, it focuses that window and moves the cursor there. Otherwise,
-it falls back to the default behavior of switching buffers in the current window.
 
 ### Project-specific global marks
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,21 @@ require("recall").setup({
 })
 ```
 
+### Reusing opened windows
+
+When navigating marks in a split-window layout, `recall` can reuse existing windows
+instead of switching buffers in the current window.
+
+```lua
+require("recall").setup({
+  reuse_opened_windows = true  -- default: false
+})
+```
+
+When enabled, `recall` first checks if the target mark's buffer is already open in
+another window. If so, it focuses that window and moves the cursor there. Otherwise,
+it falls back to the default behavior of switching buffers in the current window.
+
 ### Project-specific global marks
 
 Neovim stores global mark information in the [`shada` file][shada-docs]. The
@@ -269,3 +284,4 @@ To format the code in this repository, run [`./format.sh`](./format.sh).
 ## Licensing
 
 [The MIT license](./LICENSE.md).
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ streamlining their usage and enhancing their visibility and navigability.
 - Simplifies mark setting and removal with `:RecallToggle`, abstracting away
   the burden of choosing and remembering specific letters.
 - When navigating marks in a split-window layout, `recall` reuses existing windows
-instead of switching buffers in the current window.
+  instead of switching buffers in the current window.
 
 Recall attempts to eliminate the cognitive overhead associated with mark
 management, enabling you to focus on your workflow, not on mark administration.

--- a/lua/recall/config.lua
+++ b/lua/recall/config.lua
@@ -3,6 +3,7 @@ local M = {}
 M.opts = {
   sign = "",
   sign_highlight = "@comment.note",
+  reuse_opened_windows = false,
 
   telescope = {
     autoload = true,
@@ -48,6 +49,8 @@ function M.setup(opts)
       require("recall.telescope").autoload()
     end)
   end
+
+  require("recall.navigation").reuse_opened_windows = M.opts.reuse_opened_windows
 end
 
 return M

--- a/lua/recall/config.lua
+++ b/lua/recall/config.lua
@@ -50,7 +50,7 @@ function M.setup(opts)
     end)
   end
 
-  require("recall.navigation").reuse_opened_windows = M.opts.reuse_opened_windows
+  require("recall.navigation").opts.reuse_opened_windows = M.opts.reuse_opened_windows
 end
 
 return M

--- a/lua/recall/config.lua
+++ b/lua/recall/config.lua
@@ -3,7 +3,6 @@ local M = {}
 M.opts = {
   sign = "",
   sign_highlight = "@comment.note",
-  reuse_opened_windows = false,
 
   telescope = {
     autoload = true,
@@ -49,8 +48,6 @@ function M.setup(opts)
       require("recall.telescope").autoload()
     end)
   end
-
-  require("recall.navigation").opts.reuse_opened_windows = M.opts.reuse_opened_windows
 end
 
 return M

--- a/lua/recall/navigation.lua
+++ b/lua/recall/navigation.lua
@@ -66,7 +66,8 @@ M.goto_mark = function(direction)
   local mark = M.find_mark(direction)
   if mark then
     if M.opts.reuse_opened_windows then
-      local win_id_to_reuse = vim.fn.bufwinid(mark.file)
+      local bufnr = vim.fn.bufnr(mark.file)
+      local win_id_to_reuse = vim.fn.bufwinid(bufnr)
       if win_id_to_reuse ~= -1 then
         utils.set_cursor_for_mark_in_window(win_id_to_reuse, mark)
         return

--- a/lua/recall/navigation.lua
+++ b/lua/recall/navigation.lua
@@ -2,6 +2,10 @@ local utils = require("recall.utils")
 
 local M = {}
 
+M.opts = {
+  reuse_opened_windows = false,
+}
+
 M.latest_mark_from_jumplist = function(marks)
   local jumplist = vim.fn.getjumplist()
   for i = #jumplist[1], 1, -1 do
@@ -61,8 +65,14 @@ end
 M.goto_mark = function(direction)
   local mark = M.find_mark(direction)
   if mark then
-    vim.cmd("silent buffer " .. mark.file)
-    vim.api.nvim_win_set_cursor(0, { mark.pos[2], mark.pos[3] })
+    if M.opts.reuse_opened_windows then
+      local win_id_to_reuse = vim.fn.bufwinid(mark.file)
+      if win_id_to_reuse ~= -1 then
+        utils.set_cursor_for_mark_in_window(win_id_to_reuse, mark)
+        return
+      end
+    end
+    utils.set_cursor_for_mark_in_current_window(mark)
   else
     print("No global marks set")
   end

--- a/lua/recall/navigation.lua
+++ b/lua/recall/navigation.lua
@@ -2,10 +2,6 @@ local utils = require("recall.utils")
 
 local M = {}
 
-M.opts = {
-  reuse_opened_windows = false,
-}
-
 M.latest_mark_from_jumplist = function(marks)
   local jumplist = vim.fn.getjumplist()
   for i = #jumplist[1], 1, -1 do
@@ -65,15 +61,16 @@ end
 M.goto_mark = function(direction)
   local mark = M.find_mark(direction)
   if mark then
-    if M.opts.reuse_opened_windows then
-      local bufnr = vim.fn.bufnr(mark.file)
-      local win_id_to_reuse = vim.fn.bufwinid(bufnr)
-      if win_id_to_reuse ~= -1 then
-        utils.set_cursor_for_mark_in_window(win_id_to_reuse, mark)
-        return
-      end
+    local bufnr = vim.fn.bufnr(mark.file)
+    if bufnr == -1 then
+      vim.cmd("silent buffer " .. mark.file) -- loads buffer if not loaded at all
     end
-    utils.set_cursor_for_mark_in_current_window(mark)
+    local window_id_to_reuse = vim.fn.bufwinid(bufnr)
+    if window_id_to_reuse ~= -1 then
+      utils.set_cursor_for_mark_in_window(window_id_to_reuse, mark)
+    else
+      utils.set_cursor_for_mark_in_current_window(mark)
+    end
   else
     print("No global marks set")
   end

--- a/lua/recall/utils.lua
+++ b/lua/recall/utils.lua
@@ -44,7 +44,6 @@ M.set_cursor_for_mark_in_window = function(window_id, mark)
 end
 
 M.set_cursor_for_mark_in_current_window = function(mark)
-  vim.cmd("silent buffer " .. mark.file)
   M.set_cursor_for_mark_in_window(0, mark)
 end
 

--- a/lua/recall/utils.lua
+++ b/lua/recall/utils.lua
@@ -37,11 +37,14 @@ M.sorted_global_marks = function()
 end
 
 M.set_cursor_for_mark_in_window = function(window_id, mark)
-  vim.cmd("silent buffer " .. mark.file)
+  if window_id ~= 0 then
+    vim.api.nvim_set_current_win(window_id)
+  end
   vim.api.nvim_win_set_cursor(window_id, { mark.pos[2], mark.pos[3] })
 end
 
 M.set_cursor_for_mark_in_current_window = function(mark)
+  vim.cmd("silent buffer " .. mark.file)
   M.set_cursor_for_mark_in_window(0, mark)
 end
 

--- a/lua/recall/utils.lua
+++ b/lua/recall/utils.lua
@@ -36,4 +36,13 @@ M.sorted_global_marks = function()
   return marks
 end
 
+M.set_cursor_for_mark_in_window = function(window_id, mark)
+  vim.api.nvim_win_set_cursor(window_id, { mark.pos[2], mark.pos[3] })
+end
+
+M.set_cursor_for_mark_in_current_window = function(mark)
+  vim.cmd("silent buffer " .. mark.file)
+  M.set_cursor_for_mark_in_window(0, mark)
+end
+
 return M

--- a/lua/recall/utils.lua
+++ b/lua/recall/utils.lua
@@ -40,7 +40,7 @@ M.set_cursor_for_mark_in_window = function(window_id, mark)
   if window_id ~= 0 then
     vim.api.nvim_set_current_win(window_id)
   end
-  vim.api.nvim_win_set_cursor(window_id, { mark.pos[2], mark.pos[3] })
+  vim.api.nvim_win_set_cursor(0, { mark.pos[2], mark.pos[3] })
 end
 
 M.set_cursor_for_mark_in_current_window = function(mark)

--- a/lua/recall/utils.lua
+++ b/lua/recall/utils.lua
@@ -37,11 +37,11 @@ M.sorted_global_marks = function()
 end
 
 M.set_cursor_for_mark_in_window = function(window_id, mark)
+  vim.cmd("silent buffer " .. mark.file)
   vim.api.nvim_win_set_cursor(window_id, { mark.pos[2], mark.pos[3] })
 end
 
 M.set_cursor_for_mark_in_current_window = function(mark)
-  vim.cmd("silent buffer " .. mark.file)
   M.set_cursor_for_mark_in_window(0, mark)
 end
 

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -220,10 +220,10 @@ describe("Recall", function()
 
   it("reuses opened windows when reuse_opened_windows is enabled", function()
     local bufnr1 = create_temp_buffer()
-    local win1 = vim.api.nvim_open_win(bufnr1, true, { split = 'left' })
+    local win1 = vim.api.nvim_open_win(bufnr1, true, { split = "left" })
 
     local bufnr2 = create_temp_buffer()
-    local win2 = vim.api.nvim_open_win(bufnr2, true, { split = 'right' })
+    local win2 = vim.api.nvim_open_win(bufnr2, true, { split = "right" })
     assert.are.not_equal(win1, win2)
 
     vim.api.nvim_set_current_win(win1)

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -204,4 +204,52 @@ describe("Recall", function()
     assert.are.equal(results[3].lnum, 20)
     assert.are.equal(results[3].col, 0)
   end)
+
+  it("reuses opened windows when reuse_opened_windows is enabled", function()
+    -- Create a second buffer
+    local bufnr2 = vim.api.nvim_create_buf(true, false)
+    set_lines(bufnr2, line_count)
+    local temp_path2 = luv.os_tmpdir() .. "/nvim-recall-test2-" .. luv.hrtime() .. ".txt"
+    if jit and jit.os == "OSX" then
+      temp_path2 = "/private" .. temp_path2
+    end
+    table.insert(temp_paths, temp_path2)
+    vim.api.nvim_buf_set_name(bufnr2, temp_path2)
+    vim.api.nvim_buf_set_option(bufnr2, "modified", false)
+    vim.cmd("w")
+
+    -- Enable reuse_opened_windows
+    recall.setup({ reuse_opened_windows = true })
+
+    -- Place mark A in bufnr at line 10
+    vim.api.nvim_set_current_buf(bufnr)
+    place_cursor(10, 0)
+    recall.toggle()
+
+    -- Place mark B in bufnr2 at line 20
+    vim.api.nvim_set_current_buf(bufnr2)
+    place_cursor(20, 0)
+    recall.toggle()
+
+    -- Create a split window showing bufnr
+    vim.api.nvim_set_current_buf(bufnr)
+    local win1 = vim.api.nvim_get_current_win()
+    vim.cmd("vsplit")
+    local win2 = vim.api.nvim_get_current_win()
+    assert.are.not_equal(win1, win2)
+    vim.api.nvim_set_current_win(win2)
+    vim.api.nvim_set_current_buf(bufnr2)
+
+    -- From win2 (bufnr2), go to prev mark (should be mark A in bufnr)
+    -- Should switch to win1 instead of changing buffer in win2
+    recall.goto_prev()
+
+    local current_win = vim.api.nvim_get_current_win()
+    local current_buf = vim.api.nvim_get_current_buf()
+    local cursor_pos = vim.api.nvim_win_get_cursor(current_win)
+
+    assert.are.equal(current_win, win1, "Should reuse the window already displaying the target buffer")
+    assert.are.equal(current_buf, bufnr)
+    assert.are.same(cursor_pos, { 10, 0 })
+  end)
 end)

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -131,20 +131,27 @@ describe("Recall", function()
     place_cursor(unpack(c_pos))
     recall.toggle()
 
-    recall.goto_prev()
-    assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
+    for _, reuse_opened_windows in ipairs({ true, false }) do
+      require('recall.navigation').opts.reuse_opened_windows = reuse_opened_windows
 
-    recall.goto_prev()
-    assert.are.same(a_pos, vim.api.nvim_win_get_cursor(0))
+      recall.goto_prev()
+      assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
 
-    recall.goto_next()
-    assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
+      recall.goto_prev()
+      assert.are.same(a_pos, vim.api.nvim_win_get_cursor(0))
 
-    recall.goto_next()
-    assert.are.same(c_pos, vim.api.nvim_win_get_cursor(0))
+      recall.goto_next()
+      assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
 
-    recall.goto_prev()
-    assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
+      recall.goto_next()
+      assert.are.same(c_pos, vim.api.nvim_win_get_cursor(0))
+
+      recall.goto_prev()
+      assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
+
+      recall.goto_next()
+      assert.are.same(c_pos, vim.api.nvim_win_get_cursor(0))
+    end
   end)
 
   it("can clear all marks", function()
@@ -206,7 +213,7 @@ describe("Recall", function()
   end)
 
   it("reuses opened windows when reuse_opened_windows is enabled", function()
-    -- Create a second buffer
+    -- Create a second buffer for a second window
     local bufnr2 = vim.api.nvim_create_buf(true, false)
     set_lines(bufnr2, line_count)
     local temp_path2 = luv.os_tmpdir() .. "/nvim-recall-test2-" .. luv.hrtime() .. ".txt"
@@ -218,27 +225,21 @@ describe("Recall", function()
     vim.api.nvim_buf_set_option(bufnr2, "modified", false)
     vim.cmd("w")
 
-    -- Enable reuse_opened_windows
     recall.setup({ reuse_opened_windows = true })
 
-    -- Create a split window showing bufnr
     vim.api.nvim_set_current_buf(bufnr)
     local win1 = vim.api.nvim_get_current_win()
     local win2 = vim.api.nvim_open_win(bufnr2, true, { split = 'right' })
     assert.are.not_equal(win1, win2)
 
-    -- Place mark A in bufnr at line 10
     vim.api.nvim_set_current_win(win1)
     place_cursor(10, 1)
     recall.mark()
 
-    -- Place mark B in bufnr2 at line 20
     vim.api.nvim_set_current_win(win2)
     place_cursor(20, 1)
     recall.mark()
 
-    -- From win2 (bufnr2), go to prev mark (should be mark A in bufnr)
-    -- Should switch to win1 instead of changing buffer in win2
     vim.api.nvim_set_current_win(win2)
     place_cursor(20, 1)
     recall.goto_next()

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -140,7 +140,6 @@ describe("Recall", function()
     place_cursor(unpack(c_pos))
     recall.toggle()
 
-
     recall.goto_prev()
     assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
 

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -221,28 +221,27 @@ describe("Recall", function()
     -- Enable reuse_opened_windows
     recall.setup({ reuse_opened_windows = true })
 
-    -- Place mark A in bufnr at line 10
-    vim.api.nvim_set_current_buf(bufnr)
-    place_cursor(10, 0)
-    recall.toggle()
-
-    -- Place mark B in bufnr2 at line 20
-    vim.api.nvim_set_current_buf(bufnr2)
-    place_cursor(20, 0)
-    recall.toggle()
-
     -- Create a split window showing bufnr
     vim.api.nvim_set_current_buf(bufnr)
     local win1 = vim.api.nvim_get_current_win()
-    vim.cmd("vsplit")
-    local win2 = vim.api.nvim_get_current_win()
+    local win2 = vim.api.nvim_open_win(bufnr2, true, { split = 'right' })
     assert.are.not_equal(win1, win2)
+
+    -- Place mark A in bufnr at line 10
+    vim.api.nvim_set_current_win(win1)
+    place_cursor(10, 1)
+    recall.mark()
+
+    -- Place mark B in bufnr2 at line 20
     vim.api.nvim_set_current_win(win2)
-    vim.api.nvim_set_current_buf(bufnr2)
+    place_cursor(20, 1)
+    recall.mark()
 
     -- From win2 (bufnr2), go to prev mark (should be mark A in bufnr)
     -- Should switch to win1 instead of changing buffer in win2
-    recall.goto_prev()
+    vim.api.nvim_set_current_win(win2)
+    place_cursor(20, 1)
+    recall.goto_next()
 
     local current_win = vim.api.nvim_get_current_win()
     local current_buf = vim.api.nvim_get_current_buf()
@@ -250,6 +249,16 @@ describe("Recall", function()
 
     assert.are.equal(current_win, win1, "Should reuse the window already displaying the target buffer")
     assert.are.equal(current_buf, bufnr)
-    assert.are.same(cursor_pos, { 10, 0 })
+    assert.are.same(cursor_pos, { 10, 1 })
+
+    recall.goto_next()
+
+    current_win = vim.api.nvim_get_current_win()
+    current_buf = vim.api.nvim_get_current_buf()
+    cursor_pos = vim.api.nvim_win_get_cursor(current_win)
+
+    assert.are.equal(current_win, win2, "Should reuse the window already displaying the target buffer")
+    assert.are.equal(current_buf, bufnr2)
+    assert.are.same(cursor_pos, { 20, 1 })
   end)
 end)

--- a/tests/plenary/recall_spec.lua
+++ b/tests/plenary/recall_spec.lua
@@ -49,14 +49,10 @@ describe("Recall", function()
   local temp_paths = {}
   local cwd = vim.fn.getcwd()
 
-  before_each(function()
-    local telescope = require("telescope")
-    telescope.setup({})
-    recall.setup({})
-
-    bufnr = vim.api.nvim_create_buf(true, false)
-    vim.api.nvim_set_current_buf(bufnr)
-    set_lines(bufnr, line_count)
+  local function create_temp_buffer()
+    local _bufnr = vim.api.nvim_create_buf(true, false)
+    vim.api.nvim_set_current_buf(_bufnr)
+    set_lines(_bufnr, line_count)
 
     local temp_path = luv.os_tmpdir() .. "/nvim-recall-test-" .. luv.hrtime() .. ".txt"
     if jit and jit.os == "OSX" then
@@ -65,12 +61,14 @@ describe("Recall", function()
     end
     table.insert(temp_paths, temp_path)
 
-    vim.api.nvim_buf_set_name(bufnr, temp_path)
-    vim.api.nvim_buf_set_option(bufnr, "modified", false)
+    vim.api.nvim_buf_set_name(_bufnr, temp_path)
+    vim.api.nvim_buf_set_option(_bufnr, "modified", false)
     vim.cmd("w")
-  end)
 
-  after_each(function()
+    return _bufnr
+  end
+
+  local function remove_temp_buffers_and_marks()
     vim.cmd("bufdo! bdelete")
     vim.cmd("delmarks A-Z")
 
@@ -80,6 +78,17 @@ describe("Recall", function()
 
     temp_paths = {}
     vim.api.nvim_set_current_dir(cwd)
+  end
+
+  before_each(function()
+    local telescope = require("telescope")
+    telescope.setup({})
+    recall.setup({})
+    bufnr = create_temp_buffer()
+  end)
+
+  after_each(function()
+    remove_temp_buffers_and_marks()
   end)
 
   it("can toggle marks and show/hide signs", function()
@@ -131,27 +140,24 @@ describe("Recall", function()
     place_cursor(unpack(c_pos))
     recall.toggle()
 
-    for _, reuse_opened_windows in ipairs({ true, false }) do
-      require('recall.navigation').opts.reuse_opened_windows = reuse_opened_windows
 
-      recall.goto_prev()
-      assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
+    recall.goto_prev()
+    assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
 
-      recall.goto_prev()
-      assert.are.same(a_pos, vim.api.nvim_win_get_cursor(0))
+    recall.goto_prev()
+    assert.are.same(a_pos, vim.api.nvim_win_get_cursor(0))
 
-      recall.goto_next()
-      assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
+    recall.goto_next()
+    assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
 
-      recall.goto_next()
-      assert.are.same(c_pos, vim.api.nvim_win_get_cursor(0))
+    recall.goto_next()
+    assert.are.same(c_pos, vim.api.nvim_win_get_cursor(0))
 
-      recall.goto_prev()
-      assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
+    recall.goto_prev()
+    assert.are.same(b_pos, vim.api.nvim_win_get_cursor(0))
 
-      recall.goto_next()
-      assert.are.same(c_pos, vim.api.nvim_win_get_cursor(0))
-    end
+    recall.goto_next()
+    assert.are.same(c_pos, vim.api.nvim_win_get_cursor(0))
   end)
 
   it("can clear all marks", function()
@@ -213,34 +219,25 @@ describe("Recall", function()
   end)
 
   it("reuses opened windows when reuse_opened_windows is enabled", function()
-    -- Create a second buffer for a second window
-    local bufnr2 = vim.api.nvim_create_buf(true, false)
-    set_lines(bufnr2, line_count)
-    local temp_path2 = luv.os_tmpdir() .. "/nvim-recall-test2-" .. luv.hrtime() .. ".txt"
-    if jit and jit.os == "OSX" then
-      temp_path2 = "/private" .. temp_path2
-    end
-    table.insert(temp_paths, temp_path2)
-    vim.api.nvim_buf_set_name(bufnr2, temp_path2)
-    vim.api.nvim_buf_set_option(bufnr2, "modified", false)
-    vim.cmd("w")
+    local bufnr1 = create_temp_buffer()
+    local win1 = vim.api.nvim_open_win(bufnr1, true, { split = 'left' })
 
-    recall.setup({ reuse_opened_windows = true })
-
-    vim.api.nvim_set_current_buf(bufnr)
-    local win1 = vim.api.nvim_get_current_win()
+    local bufnr2 = create_temp_buffer()
     local win2 = vim.api.nvim_open_win(bufnr2, true, { split = 'right' })
     assert.are.not_equal(win1, win2)
 
     vim.api.nvim_set_current_win(win1)
+    vim.api.nvim_set_current_buf(bufnr1)
     place_cursor(10, 1)
     recall.mark()
 
     vim.api.nvim_set_current_win(win2)
+    vim.api.nvim_set_current_buf(bufnr2)
     place_cursor(20, 1)
     recall.mark()
 
     vim.api.nvim_set_current_win(win2)
+    vim.api.nvim_set_current_buf(bufnr2)
     place_cursor(20, 1)
     recall.goto_next()
 
@@ -249,7 +246,7 @@ describe("Recall", function()
     local cursor_pos = vim.api.nvim_win_get_cursor(current_win)
 
     assert.are.equal(current_win, win1, "Should reuse the window already displaying the target buffer")
-    assert.are.equal(current_buf, bufnr)
+    assert.are.equal(current_buf, bufnr1)
     assert.are.same(cursor_pos, { 10, 1 })
 
     recall.goto_next()


### PR DESCRIPTION
When enabled, navigation reuses existing windows displaying the target buffer instead of switching buffers in the current window. Useful for split-window workflows. Fixes #14 

For disclaimer purposes, I used LLMs to help me with tests and how to run tests since I've never ever ran tests in Lua before. It took a fair amount of time to debug a test since I'm not familiar with that, but I think it works. I also tested it locally by installing the plugin from my personal branch. 

The code implementation while inspired by LLM was completely rewritten and improved by me. The README and the CHANGELOG were written by me and polished my LLM since English is not my native language. 